### PR TITLE
Added macro _fff_write_multiple

### DIFF
--- a/fifofast.h
+++ b/fifofast.h
@@ -394,7 +394,7 @@ do{																\
     if (btw > 0) {                                              \
         memcpy(&_id.data[_id.write], (newdata)+tocopy, btw);    \
         _id.write = btw;                                        \
-        _id.level += tocopy;                                    \
+        _id.level += btw;                                    \
     }                                                           \
 }while(0)
 

--- a/fifofast_demo.c
+++ b/fifofast_demo.c
@@ -40,6 +40,7 @@ int main(void)
 	fifofast_test_macro_remove_lite(0x50);
 	fifofast_test_macro_remove(0x60);
 	fifofast_test_macro_rebase(0x70);
+	fifofast_test_macro_multiple_write(0x80);
 	
 	fifofast_test_func_initial((fff_proto_t*)&fifo_uint8p);
 	fifofast_test_func_write((fff_proto_t*)&fifo_uint8p, 0x80);

--- a/fifofast_test.c
+++ b/fifofast_test.c
@@ -374,6 +374,32 @@ void fifofast_test_macro_rebase(uint8_t startvalue)
 	_fff_reset(fifo_uint8);
 }
 
+void fifofast_test_macro_multiple_write(uint8_t startvalue) {
+	uint8_t multidata[3] = {startvalue + 3, startvalue + 4, startvalue + 5};
+
+	_fff_write_lite(fifo_uint8, startvalue+0);
+	_fff_write_lite(fifo_uint8, startvalue+1);
+	_fff_write_lite(fifo_uint8, startvalue+2);
+
+	_fff_remove_lite(fifo_uint8, 2);
+
+	_fff_write_multiple(fifo_uint8, multidata, 3);
+
+
+	UT_ASSERT(_fff_peek(fifo_uint8, 0)		== startvalue+2);
+	UT_ASSERT(_fff_peek(fifo_uint8, 1)		== startvalue+3);
+	UT_ASSERT(_fff_peek(fifo_uint8, 2)		== startvalue+4);
+	UT_ASSERT(_fff_peek(fifo_uint8, 3)		== startvalue+5);
+
+
+	UT_ASSERT(_fff_mem_level(fifo_uint8)	== 4);
+	UT_ASSERT(_fff_mem_free(fifo_uint8)		== 0);
+	UT_ASSERT(_fff_is_empty(fifo_uint8)		== 0);
+	UT_ASSERT(_fff_is_full(fifo_uint8)		== 1);
+	
+
+	_fff_reset(fifo_uint8);
+}
 
 //////////////////////////////////////////////////////////////////////////
 // Test Functions

--- a/fifofast_test.h
+++ b/fifofast_test.h
@@ -27,6 +27,7 @@ void fifofast_test_macro_add(uint8_t startvalue);
 void fifofast_test_macro_remove_lite(uint8_t startvalue);
 void fifofast_test_macro_remove(uint8_t startvalue);
 void fifofast_test_macro_rebase(uint8_t startvalue);
+void fifofast_test_macro_multiple_write(uint8_t startvalue);
 
 void fifofast_test_func_initial(fff_proto_t* fifo);
 void fifofast_test_func_write(fff_proto_t* fifo, uint8_t startvalue);

--- a/utility/macros/com/macro_math.h
+++ b/utility/macros/com/macro_math.h
@@ -42,6 +42,10 @@
 #define _shift_right(arg, shiftAmount)		\
 	(shiftAmount > 0 ? arg >> shiftAmount : arg << (-shiftAmount))
 
+// returns the minimum of both parameters, if x == y, y is returned
+#define _min(x, y)                           \
+    (((x) > (y)) ? (y) : (x))
+
 // returns the mathematical function log2(x), rounded down to nearest integer
 // this marco-like function makes use of a GCC build-in function and can be used eg. for if(log2(x)>y)
 // If a literal is passed to this function, the result is calculated at compile time and stored in flash.


### PR DESCRIPTION
The macro allows to write an array of elements to the fifo in a circular buffer manner.